### PR TITLE
adds student view data and user state

### DIFF
--- a/diagnostic_feedback/quiz.py
+++ b/diagnostic_feedback/quiz.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import copy
+from webob import Response
 from xblock.core import XBlock
 from xblock.fields import Scope, String, List, Integer, Dict, Boolean, Float
 from xblock.fragment import Fragment
@@ -239,6 +240,36 @@ class QuizBlock(ResourceMixin, QuizResultMixin, ExportDataBlock, XBlockWithTrans
                 'quiz_type': self.quiz_type,
                 'quiz_title': self.title
             }
+        )
+
+    def student_view_data(self, context=None):
+        """
+        Returns a JSON representation of the Diagnostic Feedback Xblock, that
+        can be retrieved using Course Block API.
+        """
+        return {
+            'quiz_type': self.quiz_type,
+            'quiz_title': self.title,
+            'questions': self.questions,
+            'description': self.description,
+        }
+
+    @XBlock.handler
+    def student_view_user_state(self, data, suffix=''):
+        """
+        Returns a JSON representation of the student data for Diagnostic Feedback Xblock
+        """
+        response = {
+            'student_choices': self.student_choices,
+            'student_result': self.student_result,
+            'current_step': self.current_step,
+            'completed': self.completed,
+        }
+
+        return Response(
+            json.dumps(response),
+            content_type='application/json',
+            charset='utf8'
         )
 
     def get_attached_groups(self):

--- a/diagnostic_feedback/tests/unit/test_student_view_data.py
+++ b/diagnostic_feedback/tests/unit/test_student_view_data.py
@@ -1,0 +1,77 @@
+import json
+
+from xblock.field_data import DictFieldData
+
+from base_test import BaseTest
+from diagnostic_feedback.quiz import QuizBlock
+from ..utils import MockRuntime
+
+
+class StudentViewDataTest(BaseTest):
+    """
+    Tests for XBlock Diagnostic Feedback. Student View Data
+    """
+    def setUp(self):
+        """
+        Test case setup
+        """
+        super(StudentViewDataTest, self).setUp()
+        self.runtime = MockRuntime()
+        self.diagnostic_feedback_data = {
+            'questions': [
+                {
+                    'group': 'Default Group',
+                    'title': 'Test Title',
+                    'text': '<p>Test Question Text</p>',
+                    'choices': [
+                        {
+                            'name': '<p>Dummy</p>'
+                        },
+                        {
+                            'name': '<p>Test Dummy</p>'
+                        }
+                    ],
+                }
+            ],
+            'description': 'Test Description',
+            'title': 'New Quiz',
+            'quiz_type': 'BFQ'
+        }
+
+        self.diagnostic_feedback_block = QuizBlock(
+            self.runtime,
+            DictFieldData(self.diagnostic_feedback_data),
+            None
+        )
+
+    def test_student_view_data(self):
+        """
+        Test the student_view_data results.
+        """
+        expected_diagnostic_feedback_data = {
+            'quiz_type': self.diagnostic_feedback_data['quiz_type'],
+            'quiz_title': self.diagnostic_feedback_data['title'],
+            'questions': self.diagnostic_feedback_data['questions'],
+            'description': self.diagnostic_feedback_data['description'],
+        }
+
+        student_view_data = self.diagnostic_feedback_block.student_view_data()
+        self.assertEqual(student_view_data, expected_diagnostic_feedback_data)
+
+    def test_student_view_user_state_handler(self):
+        """
+        Test the student_view_user_state handler results.
+        """
+        response = json.loads(
+            self.diagnostic_feedback_block.handle(
+                'student_view_user_state',
+                self.make_request('', method='GET')
+            ).body
+        )
+        expected_diagnostic_feedback_response = {
+            u'student_choices': {},
+            u'student_result': u'',
+            u'current_step': 0,
+            u'completed': False,
+        }
+        self.assertEqual(response, expected_diagnostic_feedback_response)

--- a/diagnostic_feedback/tests/utils.py
+++ b/diagnostic_feedback/tests/utils.py
@@ -1,0 +1,13 @@
+# Test mocks and helpers
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
+
+
+# pylint: disable=abstract-method
+class MockRuntime(TestRuntime):
+    """
+    Provides a mock XBlock runtime object.
+    """
+    def __init__(self, **kwargs):
+        field_data = kwargs.get('field_data', KvsFieldData(DictKeyValueStore()))
+        super(MockRuntime, self).__init__(field_data=field_data)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-diagnostic-feedback',
-    version='0.2.1',
+    version='0.2.2',
     description='XBlock - Create quiz to generate diagnostic feedback',
     packages=[
         'diagnostic_feedback',


### PR DESCRIPTION
This PR adds `student_view_data` to Diagnostic Feedback block which returns a JSON representation of the Diagnostic Feedback Xblock, that can be retrieved using Course Block API. It also adds `student_view_user_state` handler to get user state data.

@mtyaka @bradenmacdonald could you please review?